### PR TITLE
Align project with cookiecutter

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - run: python -m pip install --upgrade build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.11']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -m pip install --upgrade pip
+      - run: pip install -e .[test]
+      - run: pytest

--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@ llm codesearch "How is authentication implemented?"
 ```
 
 Refer to the module docstrings for details on the implementation.
+
+## Development
+
+Create a virtual environment and install the project with test dependencies:
+
+```bash
+pip install -e .[test]
+```
+
+Run the tests using `pytest` or `unittest`:
+
+```bash
+pytest
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,5 +6,12 @@ readme = "README.md"
 requires-python = ">=3.9"
 dependencies = ["click"]
 
+[project.optional-dependencies]
+test = ["pytest"]
+
+[build-system]
+requires = ["setuptools>=61", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project.entry-points."llm.plugins"]
 codesearch = "llm_codesearch:register"


### PR DESCRIPTION
## Summary
- add GitHub workflows for testing and publishing
- document how to run tests
- support optional `test` extras in pyproject

## Testing
- `python -m unittest discover -v tests`